### PR TITLE
Fix build issue

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 export CI=true
-npm build
+npm run build
 npm test ${@}


### PR DESCRIPTION
The command "npm build" should actually be "npm run build".

"npm test" is a [shortcut](https://docs.npmjs.com/cli/v11/commands/npm-test) and valid to use whereas "npm build" is an [internal command](https://stackoverflow.com/questions/43664200/what-is-the-difference-between-npm-install-and-npm-run-build) not meant for normal usage. Normal usage like for a CI/CD pipeline or during development, should use "npm run build".